### PR TITLE
return '! ' after micro8 reactions, just like other tasks.

### DIFF
--- a/src/tasks/challenge/round1/challenge_micro.py
+++ b/src/tasks/challenge/round1/challenge_micro.py
@@ -707,7 +707,7 @@ class Micro8Task(MicroBase):
 
             def micro8_feedback(is_correct, question):
                 reaction = "correct" if is_correct else "false"
-                return reaction + '!' + sentence
+                return reaction + '! ' + sentence
             return question, [sentence], micro8_feedback
 
         return TaskGenerator(micro8_question, '', None, ';')


### PR DESCRIPTION
Unlike other tasks, micro8 returns '!' (no space) instead of '! ' in feedbacks.  This modification makes the task a little easier to solve.
