### PR TITLE
Fix installation problem with FAdo at Mac (issue #24)

### DIFF
--- a/src/requirements/py2.txt
+++ b/src/requirements/py2.txt
@@ -1,3 +1,3 @@
 -r common.txt
-FAdo==1.3.2
-kitchen==1.2.4
+FAdo>=1.3.2
+kitchen>=1.2.4


### PR DESCRIPTION
- when installing project via "pip install -r src/requirements/py2.txt", the following error appeared on a MacBook Pro with Sierra 10.12.5: "Could not find a version that satisfies the requirement FAdo==1.3.2 (from -r src/requirements/py2.txt (line 2)) (from versions: 1.1, 1.1.1, 1.2, 1.3, 1.3.3)
No matching distribution found for FAdo==1.3.2 (from -r src/requirements/py2.txt (line 2))"

- error apparantly occured because specific FAdo version unavailable, but a subsequent version exists, which works fine